### PR TITLE
Ajout d'un sélecteur de couleur

### DIFF
--- a/src/components/ColorPicker.jsx
+++ b/src/components/ColorPicker.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { useColor } from '../contexts/ColorContext';
+
+const ColorPicker = () => {
+  const { secondaryColor, setSecondaryColor } = useColor();
+
+  const handleColorChange = (e) => {
+    setSecondaryColor(e.target.value);
+  };
+
+  return (
+    <div className="fixed bottom-4 right-4 p-2 bg-white rounded-lg shadow-lg">
+      <label htmlFor="colorPicker" className="flex items-center gap-2">
+        <span className="text-sm font-medium text-gray-700">Couleur secondaire</span>
+        <input
+          type="color"
+          id="colorPicker"
+          value={secondaryColor}
+          onChange={handleColorChange}
+          className="w-8 h-8 rounded cursor-pointer"
+        />
+      </label>
+    </div>
+  );
+};
+
+export default ColorPicker;

--- a/src/contexts/ColorContext.jsx
+++ b/src/contexts/ColorContext.jsx
@@ -1,0 +1,26 @@
+import React, { createContext, useContext, useState } from 'react';
+
+const ColorContext = createContext();
+
+export const useColor = () => {
+  const context = useContext(ColorContext);
+  if (!context) {
+    throw new Error('useColor must be used within a ColorProvider');
+  }
+  return context;
+};
+
+export const ColorProvider = ({ children }) => {
+  const [secondaryColor, setSecondaryColor] = useState('#3B82F6'); // Couleur bleue par défaut
+
+  const value = {
+    secondaryColor,
+    setSecondaryColor,
+  };
+
+  return (
+    <ColorContext.Provider value={value}>
+      {children}
+    </ColorContext.Provider>
+  );
+};


### PR DESCRIPTION
Cette PR ajoute un sélecteur de couleur qui permet de changer dynamiquement la couleur secondaire du CV.

Changements apportés :
- Ajout d'un contexte de couleur (ColorContext) pour gérer l'état global des couleurs
- Création d'un composant ColorPicker qui permet de changer la couleur secondaire
- Le sélecteur est placé en bas à droite de l'écran
- La couleur par défaut est le bleu (#3B82F6)

Pour utiliser cette fonctionnalité :
1. Wrappez votre App avec le ColorProvider
2. Ajoutez le composant ColorPicker à votre layout
3. Utilisez useColor() dans vos composants pour accéder à la couleur secondaire

Notes d'implémentation :
- Les changements de couleur sont appliqués en temps réel
- Le sélecteur est responsive et s'adapte à tous les écrans
- L'interface est intuitive avec un input de type color standard